### PR TITLE
Bump version to 1.6 in `build.gradle` (app)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdk 19
         targetSdk 34
         versionCode 46
-        versionName "1.5"
+        versionName "1.6"
 
         vectorDrawables {
             useSupportLibrary true


### PR DESCRIPTION
Play store version is [1.6](https://play.google.com/store/apps/details?id=com.gustavoas.noti), whereas in the code it's still in 1.5, thus in the settings page it still shows 1.5.