### PR TITLE
Fix crash when got notification without text

### DIFF
--- a/app/src/main/java/com/gustavoas/noti/services/NotificationListenerService.kt
+++ b/app/src/main/java/com/gustavoas/noti/services/NotificationListenerService.kt
@@ -212,10 +212,10 @@ class NotificationListenerService : NotificationListenerService() {
 
     private fun getProgressFromPercentage(sbn: StatusBarNotification): Int {
         val extras = sbn.notification.extras
-        val title = extras.getCharSequence("android.title").toString()
-        val text = extras.getCharSequence("android.text").toString()
-        val subText = extras.getCharSequence("android.subText").toString()
-        val bigText = extras.getCharSequence("android.bigText").toString()
+        val title   = extras.getCharSequence("android.title"  )?.toString() ?: ""
+        val text    = extras.getCharSequence("android.text"   )?.toString() ?: ""
+        val subText = extras.getCharSequence("android.subText")?.toString() ?: ""
+        val bigText = extras.getCharSequence("android.bigText")?.toString() ?: ""
         val textLines = extras.getCharSequenceArray("android.textLines")
 
         val percentageProgress = title.substringBefore("%").toFloatOrNull() ?:


### PR DESCRIPTION
Fixes crash when Google Backup is in progress (or any other notification with progress bar but without text is shown):
```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.Object.toString()' on a null object reference
	at com.gustavoas.noti.services.NotificationListenerService.getProgressFromPercentage(NotificationListenerService.kt:216)
	at com.gustavoas.noti.services.NotificationListenerService.onNotificationPosted(NotificationListenerService.kt:75)
	at android.service.notification.NotificationListenerService.onNotificationPosted(NotificationListenerService.java:450)
	at android.service.notification.NotificationListenerService$MyHandler.handleMessage(NotificationListenerService.java:2311)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:204)
	at android.os.Looper.loop(Looper.java:291)
	at android.app.ActivityThread.main(ActivityThread.java:8129)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:588)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1019)
```

P.S. My device is TECNO Camon 20 Pro 5G, Android 13